### PR TITLE
fix(executor): prevent escaping for quotations which are parts of the arguments

### DIFF
--- a/internal/commands/create_test.go
+++ b/internal/commands/create_test.go
@@ -1,0 +1,30 @@
+package commands
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func Test_CommandParsing(t *testing.T) {
+	tests := []struct {
+		testName       string
+		command        string
+		expectedResult []string
+	}{
+		{"normal command", "run some stuff", []string{"run", "some", "stuff"}},
+		{"arguments with spaces", "run -a \"some stuff\"", []string{"run", "-a", "some stuff"}},
+		{"multiple arguments with spaces", "run -a \"some stuff\" -b \"other stuff\"", []string{"run", "-a", "some stuff", "-b", "other stuff"}},
+		{"long command", "az role assignment create --role \"Network Contributer\" --assignee ABC --scope abc",
+			[]string{"az", "role", "assignment", "create", "--role", "Network Contributer", "--assignee", "ABC", "--scope", "abc"}},
+		{"arguments with escaped backslash", "run -a \"bla\\bla\"", []string{"run", "-a", "bla\\bla"}},
+		{"arguments with quotations", "run -a object[\"property\"]", []string{"run", "-a", "object[\"property\"]"}},
+	}
+
+	for _, tt := range tests {
+		fmt.Println("Running test: " + tt.testName)
+		resultCmd := Create(tt.command)
+
+		assert.Equal(t, tt.expectedResult, resultCmd.Args)
+	}
+}

--- a/pkg/recipes/terraform/terraform.go
+++ b/pkg/recipes/terraform/terraform.go
@@ -247,12 +247,12 @@ func (tf *terraformWrapper) Init() error {
 	_, err = tf.executor.Execute("terraform" +
 		" -chdir=" + tf.terraformDirectory +
 		" init -upgrade " +
-		" --backend-config=\"subscription_id=" + tf.subscriptionId + "\"" +
-		" --backend-config=\"tenant_id=" + tf.tenantId + "\"" +
-		" --backend-config=\"storage_account_name=" + tf.stateStorageAccountName + "\"" +
-		" --backend-config=\"access_key=" + storageAccountKey + "\"" +
-		" --backend-config=\"container_name=" + tf.storageSettings.BlobContainerName + "\"" +
-		" --backend-config=\"key=" + tf.storageSettings.BlobContainerKey + "\"")
+		" --backend-config=subscription_id=" + tf.subscriptionId +
+		" --backend-config=tenant_id=" + tf.tenantId +
+		" --backend-config=storage_account_name=" + tf.stateStorageAccountName +
+		" --backend-config=access_key=" + storageAccountKey +
+		" --backend-config=container_name=" + tf.storageSettings.BlobContainerName +
+		" --backend-config=key=" + tf.storageSettings.BlobContainerKey)
 
 	if err != nil {
 		return internal.ReturnErrorOrPanic(err)
@@ -375,7 +375,7 @@ func (tf *terraformWrapper) plan(isDestroy bool) (string, error) {
 	tfCommand := "terraform" +
 		" -chdir=" + tf.terraformDirectory +
 		" plan -input=false " +
-		" -var-file=\"" + tf.GetVariablesFileName() + "\""
+		" -var-file=" + tf.GetVariablesFileName()
 
 	var localTerraformRelativePlanFilePath string
 
@@ -386,14 +386,14 @@ func (tf *terraformWrapper) plan(isDestroy bool) (string, error) {
 			return "", internal.ReturnErrorOrPanic(err)
 		}
 
-		tfCommand += " -out=\"" + localTerraformRelativePlanFilePath + "\""
+		tfCommand += " -out=" + localTerraformRelativePlanFilePath
 	} else {
 		localTerraformRelativePlanFilePath, err = GetLocalTerraformRelativePlanFilePath(tf.projectName, tf.terraformDirectory, false)
 		if err != nil {
 			return "", internal.ReturnErrorOrPanic(err)
 		}
 
-		tfCommand += " -out=\"" + localTerraformRelativePlanFilePath + "\""
+		tfCommand += " -out=" + localTerraformRelativePlanFilePath
 	}
 
 	plaintextPlanOutput, err := tf.executor.Execute(tfCommand)


### PR DESCRIPTION
@ChristianGottinger Please extend the test if new cases come to mind. This change should not break any clients, so we need to be extra careful. 