### PR TITLE
add new parameter "blobPublicAccess" and "crossTenantReplication"

### DIFF
--- a/pkg/recipes/terraform/backend_storage_settings.go
+++ b/pkg/recipes/terraform/backend_storage_settings.go
@@ -10,8 +10,10 @@ type BackendStorageSettings struct {
 	// List of IPs or CIDRs to be added to network accesslist. Networking restrictions are applied when first IP or CIDR given
 	// Small address ranges using "/31" or "/32" prefix sizes are not supported.
 	// These ranges should be configured using individual IP address rules without prefix specified.
-	AllowedIpAddresses        []string
-	ContainerCreateRetryCount uint
+	AllowedIpAddresses          []string
+	ContainerCreateRetryCount   uint
+	AllowBlobPublicAccess       bool
+	AllowCrossTenantReplication bool
 }
 
 var DefaultBackendStorageSettings = BackendStorageSettings{
@@ -22,4 +24,6 @@ var DefaultBackendStorageSettings = BackendStorageSettings{
 	BlobContainerKey:                "terraform.tfstate",
 	AllowedIpAddresses:              []string{},
 	ContainerCreateRetryCount:       10,
+	AllowBlobPublicAccess:           false,
+	AllowCrossTenantReplication:     false,
 }

--- a/pkg/recipes/terraform/terraform.go
+++ b/pkg/recipes/terraform/terraform.go
@@ -168,6 +168,20 @@ func (tf *terraformWrapper) Init() error {
 		storageAccountCreateCmd.Args = append(storageAccountCreateCmd.Args, "--require-infrastructure-encryption") // infra encryption will add another layer of encryption at rest
 	}
 
+	// set public access + cross-tenant replication explicitly so guardrail policies that require
+	// these to be false are satisfied (the create is a full PUT, so omitting them is not enough)
+	blobPublicAccess := "false"
+	if tf.storageSettings.AllowBlobPublicAccess {
+		blobPublicAccess = "true"
+	}
+	crossTenantReplication := "false"
+	if tf.storageSettings.AllowCrossTenantReplication {
+		crossTenantReplication = "true"
+	}
+	storageAccountCreateCmd.Args = append(storageAccountCreateCmd.Args,
+		"--allow-blob-public-access", blobPublicAccess,
+		"--allow-cross-tenant-replication", crossTenantReplication)
+
 	// using ExecuteCmd to skip the escaping logic of "Execute"
 	// the --tags argument does not follow the usual --argument value semantics (value(s) contain equal (=) sign and could also contain spaces)
 	_, err := tf.executor.ExecuteCmd(storageAccountCreateCmd)


### PR DESCRIPTION
required by some  guardrail policies